### PR TITLE
Indexer Improvements

### DIFF
--- a/ponder/ponder.schema.ts
+++ b/ponder/ponder.schema.ts
@@ -77,6 +77,9 @@ export const user = onchainTable("user", (t) => ({
   id: t.hex().primaryKey(), // User address
   address: t.hex().notNull(), // Same as id, kept for compatibility
 
+  // Feeding statistics
+  totalSpentFeeding: t.bigint().notNull(),
+
   // Computed fields (derived from relationships)
   // Note: These will be available via GraphQL relations, no need to store
 }));

--- a/ponder/src/index.ts
+++ b/ponder/src/index.ts
@@ -164,15 +164,21 @@ ponder.on("Aminal:FeedAminal", async ({ event, context }) => {
     .values({
       id: senderId,
       address: senderId,
+      totalSpentFeeding: 0n,
     })
     .onConflictDoNothing();
 
+  // Update user's total spent feeding
+  await db.update(user, { id: senderId }).set((row) => ({
+    totalSpentFeeding: row.totalSpentFeeding + event.transaction.value,
+  }));
+
   // Update Aminal state
-  await db.update(aminal, { id: aminalId }).set({
+  await db.update(aminal, { id: aminalId }).set((row) => ({
     energy: energy,
     totalLove: totalLove,
-    ethBalance: event.transaction.value,
-  });
+    ethBalance: row.ethBalance + event.transaction.value,
+  }));
 
   // Create or update relationship (user's love for this Aminal)
   const relationshipId = makeRelationshipId(sender, event.log.address);
@@ -223,6 +229,7 @@ ponder.on("Aminal:SkillUsed", async ({ event, context }) => {
     .values({
       id: callerId,
       address: callerId,
+      totalSpentFeeding: 0n,
     })
     .onConflictDoNothing();
 
@@ -287,6 +294,7 @@ ponder.on("GeneRegistry:GeneCreated", async ({ event, context }) => {
     .values({
       id: creatorId,
       address: creatorId,
+      totalSpentFeeding: 0n,
     })
     .onConflictDoNothing();
 
@@ -343,6 +351,7 @@ ponder.on("Genes:Transfer", async ({ event, context }) => {
     .values({
       id: newOwnerId,
       address: newOwnerId,
+      totalSpentFeeding: 0n,
     })
     .onConflictDoNothing();
 
@@ -485,6 +494,7 @@ ponder.on("GeneAuction:GeneProposed", async ({ event, context }) => {
     .values({
       id: proposerId,
       address: proposerId,
+      totalSpentFeeding: 0n,
     })
     .onConflictDoNothing();
 
@@ -520,6 +530,7 @@ ponder.on("GeneAuction:GeneVoteCast", async ({ event, context }) => {
     .values({
       id: voterId,
       address: voterId,
+      totalSpentFeeding: 0n,
     })
     .onConflictDoNothing();
 
@@ -561,6 +572,7 @@ ponder.on("GeneAuction:GeneRemovalVote", async ({ event, context }) => {
     .values({
       id: voterId,
       address: voterId,
+      totalSpentFeeding: 0n,
     })
     .onConflictDoNothing();
 
@@ -620,6 +632,7 @@ ponder.on("GeneAuction:BulkVoteCast", async ({ event, context }) => {
     .values({
       id: voterId,
       address: voterId,
+      totalSpentFeeding: 0n,
     })
     .onConflictDoNothing();
 
@@ -629,6 +642,7 @@ ponder.on("GeneAuction:BulkVoteCast", async ({ event, context }) => {
     .values({
       id: zeroAddress as Hex,
       address: zeroAddress as Hex,
+      totalSpentFeeding: 0n,
     })
     .onConflictDoNothing();
 
@@ -732,6 +746,7 @@ ponder.on("GeneAuction:GeneCreatorPayout", async ({ event, context }) => {
     .values({
       id: creatorId,
       address: creatorId,
+      totalSpentFeeding: 0n,
     })
     .onConflictDoNothing();
 


### PR DESCRIPTION
Changes Made

  1. Fixed Aminal ETH Balance Tracking

  File: ponder/src/index.ts:171-175
  - Changed from ethBalance: event.transaction.value (replacing) to ethBalance: row.ethBalance + event.transaction.value (incrementing)
  - Now correctly accumulates ETH as Aminals are fed

  2. Added User Feeding Expense Tracking

  File: ponder/ponder.schema.ts:81
  - Added totalSpentFeeding: t.bigint().notNull() field to user schema

  File: ponder/src/index.ts:172-174
  - Added logic in FeedAminal handler to increment user's totalSpentFeeding by transaction value
  - Updated all user creation sites (10 locations) to initialize totalSpentFeeding: 0n

  Now the indexer will:
  - ✅ Properly track cumulative ETH balance for each Aminal
  - ✅ Track total amount each user has spent feeding Aminals (available for profile pages)